### PR TITLE
build(deps): move npm deps to gems

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -272,16 +272,6 @@ npm_hook:
   # npm_dependencies:
   #   - "@lizardbyte/shared-web@latest"
   copy_files:
-    - src: "bootstrap/dist/css/bootstrap.min.css"
-      dst: "assets/vendor/css/bootstrap.min.css"
-    - src: "bootstrap/dist/css/bootstrap.min.css.map"
-      dst: "assets/vendor/css/bootstrap.min.css.map"
-    - src: "bootstrap/dist/js/bootstrap.min.js"
-      dst: "assets/vendor/js/bootstrap.min.js"
-    - src: "jquery/dist/jquery.min.js"
-      dst: "assets/vendor/js/jquery.min.js"
-    - src: "popper.js/dist/umd/popper.min.js"
-      dst: "assets/vendor/js/popper.min.js"
     - src: "@fortawesome/fontawesome-free/css/all.min.css"
       dst: "assets/vendor/css/fontawesome.min.css"
   copy_dirs:
@@ -291,6 +281,10 @@ npm_hook:
       dst: "assets/vendor/fonts/lora"
     - src: "@fontsource/open-sans"
       dst: "assets/vendor/fonts/open-sans"
+
+sass:
+  sass_dir: _sass
+  style: compressed
 
 # Default YAML values (more information on Jekyll's site)
 defaults:

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,6 +1,6 @@
 ---
 common-css:
-  - "/assets/vendor/css/bootstrap.min.css"
+  - "/assets/css/bootstrap.css"
   - "/assets/vendor/css/fontawesome.min.css"
   - "/assets/vendor/fonts/lora/400.css"
   - "/assets/vendor/fonts/lora/700.css"
@@ -19,9 +19,9 @@ common-css:
   - "/assets/css/bootstrap-social.css"
   - "/assets/css/beautifuljekyll.css"
 common-js:
-  - "/assets/vendor/js/bootstrap.min.js"
-  - "/assets/vendor/js/jquery.min.js"
-  - "/assets/vendor/js/popper.min.js"
+  - "/assets/js/bootstrap.js"
+  - "/assets/js/jquery.js"
+  - "/assets/js/popper.js"
   - "/assets/js/beautifuljekyll.js"
 ---
 

--- a/_layouts/minimal.html
+++ b/_layouts/minimal.html
@@ -1,11 +1,11 @@
 ---
 common-css:
-  - "/assets/vendor/css/bootstrap.min.css"
+  - "/assets/css/bootstrap.css"
   - "/assets/css/beautifuljekyll-minimal.css"
 common-js:
-  - "/assets/vendor/js/bootstrap.min.js"
-  - "/assets/vendor/js/jquery.min.js"
-  - "/assets/vendor/js/popper.min.js"
+  - "/assets/js/bootstrap.js"
+  - "/assets/js/jquery.js"
+  - "/assets/js/popper.js"
 ---
 
 <!DOCTYPE html>

--- a/assets/css/bootstrap.scss
+++ b/assets/css/bootstrap.scss
@@ -1,0 +1,1 @@
+@import "bootstrap";

--- a/assets/js/bootstrap.js
+++ b/assets/js/bootstrap.js
@@ -1,0 +1,1 @@
+//= require bootstrap

--- a/assets/js/jquery.js
+++ b/assets/js/jquery.js
@@ -1,0 +1,1 @@
+//= require jquery3

--- a/assets/js/popper.js
+++ b/assets/js/popper.js
@@ -1,0 +1,1 @@
+//= require popper

--- a/beautiful-jekyll-theme.gemspec
+++ b/beautiful-jekyll-theme.gemspec
@@ -24,7 +24,14 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown", "~> 2.3"
   spec.add_runtime_dependency "webrick", "~> 1.8"
 
+  # bootstrap
+  spec.add_runtime_dependency "bootstrap", "~> 4.4.1"
+  spec.add_runtime_dependency "jquery-rails"
+
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "appraisal", "~> 2.5"
+
+  # required for bootstrap
+  spec.add_development_dependency "dartsass-sprockets"
 end

--- a/package.json
+++ b/package.json
@@ -12,10 +12,7 @@
   "dependencies": {
     "@fontsource/lora": "5.0.19",
     "@fontsource/open-sans": "5.0.30",
-    "@fortawesome/fontawesome-free": "6.5.2",
-    "bootstrap": "4.4.1",
-    "jquery": "3.5.1",
-    "popper.js": "1.16.0"
+    "@fortawesome/fontawesome-free": "6.5.2"
   },
   "devDependencies": {
     "npm-run-all": "4.1.5"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
If we can drop the requirement for NPM/nodejs, the setup will be much easier as the current implementation requires a github workflow for deployment instead of deploying from a branch.

This doesn't actually work as is. Maybe someone else has some ideas?

Todo:
- [ ] Get bootstrap working
- [ ] Add font-awesome (https://rubygems.org/gems/font-awesome-sass)
- [ ] Move fonts back to googleapi live url

Alternatively, revert to using jsdelivr for the actual javascript, but use package.json just to get dependabot notifications? This would require manually editing the jsdelivr URLs, unless jekyll can parse the package.json file for the package version?

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

### Issues Fixed or Closed
- Fixes #(issue)

## Type of Change
<!--- Please delete options that are not relevant. --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring/documentation-blocks for new or existing methods/components
